### PR TITLE
feat: extend x, gmail, slack integrations

### DIFF
--- a/backend/apps/gmail/functions.json
+++ b/backend/apps/gmail/functions.json
@@ -1042,6 +1042,49 @@
                 }
             },
             "required": ["path"],
+        "visible": ["path"],
+        "additionalProperties": false
+        }
+    },
+    {
+        "name": "GMAIL__MESSAGES_GET_ATTACHMENT",
+        "description": "Retrieves a specific attachment from a message",
+        "tags": ["email", "attachments"],
+        "visibility": "public",
+        "active": true,
+        "protocol": "rest",
+        "protocol_data": {
+            "method": "GET",
+            "path": "/users/{userId}/messages/{messageId}/attachments/{id}",
+            "server_url": "https://gmail.googleapis.com/gmail/v1"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "object",
+                    "description": "Path parameters",
+                    "properties": {
+                        "userId": {
+                            "type": "string",
+                            "description": "The user's email address. The special value me can be used to indicate the authenticated user.",
+                            "default": "me"
+                        },
+                        "messageId": {
+                            "type": "string",
+                            "description": "The ID of the message containing the attachment"
+                        },
+                        "id": {
+                            "type": "string",
+                            "description": "The ID of the attachment"
+                        }
+                    },
+                    "required": ["messageId", "id"],
+                    "visible": ["userId", "messageId", "id"],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["path"],
             "visible": ["path"],
             "additionalProperties": false
         }

--- a/backend/apps/slack/functions.json
+++ b/backend/apps/slack/functions.json
@@ -2469,6 +2469,62 @@
     }
   },
   {
+    "name": "SLACK__REMINDERS_ADD",
+    "description": "Creates a reminder for a user",
+    "tags": ["reminders"],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "POST",
+      "path": "/reminders.add",
+      "server_url": "https://slack.com/api"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "header": {
+          "type": "object",
+          "description": "Headers for the HTTP request",
+          "properties": {
+            "Content-Type": {
+              "type": "string",
+              "description": "Content type for the request",
+              "default": "application/x-www-form-urlencoded"
+            }
+          },
+          "required": ["Content-Type"],
+          "visible": [],
+          "additionalProperties": false
+        },
+        "body": {
+          "type": "object",
+          "description": "Body parameters for creating a reminder",
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "The content of the reminder"
+            },
+            "time": {
+              "type": "string",
+              "description": "When this reminder should happen. Natural language like 'in 15 minutes', or a Unix timestamp"
+            },
+            "user": {
+              "type": "string",
+              "description": "The user to create a reminder for. Omit to create for the authed user"
+            }
+          },
+          "required": ["text", "time"],
+          "visible": ["text", "time", "user"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["header", "body"],
+      "visible": ["body"],
+      "additionalProperties": false
+    }
+  },
+  {
     "name": "SLACK__SEARCH_ALL",
     "description": "Searches for messages and files matching a query",
     "tags": ["search", "messages", "files"],

--- a/backend/apps/x/functions.json
+++ b/backend/apps/x/functions.json
@@ -1180,7 +1180,67 @@
         }
       },
       "required": ["header", "body"],
-      "visible": ["body"],
+    "visible": ["body"],
+    "additionalProperties": false
+    }
+  },
+  {
+    "name": "X__LIKE_POST",
+    "description": "Like a post on behalf of the authenticated user. Requires the user's ID and the ID of the post to like.",
+    "tags": ["posts", "likes", "social"],
+    "visibility": "public",
+    "active": true,
+    "protocol": "rest",
+    "protocol_data": {
+      "method": "POST",
+      "path": "/2/users/{id}/likes",
+      "server_url": "https://api.x.com"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "header": {
+          "type": "object",
+          "description": "HTTP headers",
+          "properties": {
+            "Content-Type": {
+              "type": "string",
+              "default": "application/json"
+            }
+          },
+          "required": ["Content-Type"],
+          "visible": [],
+          "additionalProperties": false
+        },
+        "path": {
+          "type": "object",
+          "description": "Path parameters",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "The ID of the user performing the like"
+            }
+          },
+          "required": ["id"],
+          "visible": ["id"],
+          "additionalProperties": false
+        },
+        "body": {
+          "type": "object",
+          "description": "Request body for liking a post",
+          "properties": {
+            "tweet_id": {
+              "type": "string",
+              "description": "The ID of the post to like"
+            }
+          },
+          "required": ["tweet_id"],
+          "visible": ["tweet_id"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["header", "path", "body"],
+      "visible": ["path", "body"],
       "additionalProperties": false
     }
   }


### PR DESCRIPTION
1. Added the ability to like posts in the X integration, letting users boost engagement directly from the platform.
(apps/x/functions.json)

2. Introduced Gmail attachment retrieval to access files from messages without leaving the app.
(apps/gmail/functions.json)

3. Enabled creating Slack reminders so teams can schedule follow-ups and stay organized.
(apps/slack/functions.json)