### PR TITLE
Fix OAuth2 configurations with API-specific scopes

### DIFF
--- a/backend/apps/adobe/app.json
+++ b/backend/apps/adobe/app.json
@@ -7,24 +7,15 @@
   "description": "uLuadobe integration for AI agents",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://ims-na1.adobelogin.com/ims/authorize/v2",
-          "tokenUrl": "https://ims-na1.adobelogin.com/ims/token/v3",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ ADOBE_CLIENT_ID }}",
       "client_secret": "{{ ADOBE_CLIENT_SECRET }}",
+      "scope": "creative_sdk",
       "authorize_url": "https://ims-na1.adobelogin.com/ims/authorize/v2",
-      "access_token_url": "https://ims-na1.adobelogin.com/ims/token/v3"
+      "access_token_url": "https://ims-na1.adobelogin.com/ims/token/v3",
+      "refresh_token_url": "https://ims-na1.adobelogin.com/ims/token/v3"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/asana/app.json
+++ b/backend/apps/asana/app.json
@@ -7,24 +7,15 @@
   "description": "Integration with ASANA Support API to manage users, tickets, and organizations.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://app.asana.com/-/oauth_authorize",
-          "tokenUrl": "https://app.asana.com/-/oauth_token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ ASANA_CLIENT_ID }}",
       "client_secret": "{{ ASANA_CLIENT_SECRET }}",
+      "scope": "",
       "authorize_url": "https://app.asana.com/-/oauth_authorize",
-      "access_token_url": "https://app.asana.com/-/oauth_token"
+      "access_token_url": "https://app.asana.com/-/oauth_token",
+      "refresh_token_url": "https://app.asana.com/-/oauth_token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/calendly/app.json
+++ b/backend/apps/calendly/app.json
@@ -7,24 +7,15 @@
   "description": "Calendly integration for scheduling and managing meetings. This app allows you to automate your scheduling process, embed Calendly on your website, and manage your availability.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://auth.calendly.com/oauth/authorize",
-          "tokenUrl": "https://auth.calendly.com/oauth/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_CALENDLY_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_CALENDLY_CLIENT_SECRET }}",
+      "scope": "default",
       "authorize_url": "https://auth.calendly.com/oauth/authorize",
-      "access_token_url": "https://auth.calendly.com/oauth/token"
+      "access_token_url": "https://auth.calendly.com/oauth/token",
+      "refresh_token_url": "https://auth.calendly.com/oauth/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/canva/app.json
+++ b/backend/apps/canva/app.json
@@ -7,24 +7,15 @@
   "description": "Canva is a user-friendly graphic design platform that allows teams to create professional designs, presentations, social media graphics, and marketing materials. This integration enables AI agents to automate design workflows, manage team assets, create content at scale, and maintain brand consistency across all design projects.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://www.canva.com/api/oauth/authorize",
-          "tokenUrl": "https://api.canva.com/rest/v1/oauth/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ CLIENT_ID }}",
       "client_secret": "{{ CLIENT_SECRET }}",
+      "scope": "design:read design:content:read",
       "authorize_url": "https://www.canva.com/api/oauth/authorize",
-      "access_token_url": "https://api.canva.com/rest/v1/oauth/token"
+      "access_token_url": "https://api.canva.com/rest/v1/oauth/token",
+      "refresh_token_url": "https://api.canva.com/rest/v1/oauth/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/clickup/app.json
+++ b/backend/apps/clickup/app.json
@@ -7,24 +7,15 @@
   "description": "The ClickUp API allows you to interact with ClickUp programmatically, including workspace management, tasks, lists, folders, and more.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://app.clickup.com/api",
-          "tokenUrl": "https://api.clickup.com/api/v2/oauth/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_CLICKUP_APP_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_CLICKUP_APP_CLIENT_SECRET }}",
+      "scope": "read write",
       "authorize_url": "https://app.clickup.com/api",
-      "access_token_url": "https://api.clickup.com/api/v2/oauth/token"
+      "access_token_url": "https://api.clickup.com/api/v2/oauth/token",
+      "refresh_token_url": "https://api.clickup.com/api/v2/oauth/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/confluence/app.json
+++ b/backend/apps/confluence/app.json
@@ -7,24 +7,15 @@
   "description": "Confluence is a team workspace where knowledge and collaboration meet. This integration provides comprehensive content management capabilities for creating, organizing, and maintaining team documentation, project spaces, and knowledge bases.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://auth.atlassian.com/authorize",
-          "tokenUrl": "https://auth.atlassian.com/oauth/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_CONFLUENCE_APP_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_CONFLUENCE_APP_CLIENT_SECRET }}",
+      "scope": "read:confluence-content.all write:confluence-content",
       "authorize_url": "https://auth.atlassian.com/authorize",
-      "access_token_url": "https://auth.atlassian.com/oauth/token"
+      "access_token_url": "https://auth.atlassian.com/oauth/token",
+      "refresh_token_url": "https://auth.atlassian.com/oauth/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/discord/app.json
+++ b/backend/apps/discord/app.json
@@ -7,24 +7,15 @@
   "description": "Discord is a voice, video, and text communication service. This API allows you to interact with Discord in two ways: as a bot for automated tasks and workflows, or as a user to perform actions on behalf of a real Discord user. Whether you're building chatbots, automating workflows, or integrating Discord with other tools, this API provides the flexibility to suit your needs.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://discord.com/api/oauth2/authorize",
-          "tokenUrl": "https://discord.com/api/oauth2/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_DISCORD_APP_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_DISCORD_APP_CLIENT_SECRET }}",
+      "scope": "bot applications.commands",
       "authorize_url": "https://discord.com/api/oauth2/authorize",
-      "access_token_url": "https://discord.com/api/oauth2/token"
+      "access_token_url": "https://discord.com/api/oauth2/token",
+      "refresh_token_url": "https://discord.com/api/oauth2/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/docusign/app.json
+++ b/backend/apps/docusign/app.json
@@ -7,24 +7,15 @@
   "description": "DocuSign is the leading electronic signature platform that enables secure, legally binding digital signatures and document workflows. This integration allows AI agents to create envelopes, send documents for signature, manage recipients, track signature status, and automate document approval processes.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://account.docusign.com/oauth/auth",
-          "tokenUrl": "https://account.docusign.com/oauth/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ DOCUSIGN_CLIENT_ID }}",
       "client_secret": "{{ DOCUSIGN_CLIENT_SECRET }}",
+      "scope": "signature impersonation",
       "authorize_url": "https://account.docusign.com/oauth/auth",
-      "access_token_url": "https://account.docusign.com/oauth/token"
+      "access_token_url": "https://account.docusign.com/oauth/token",
+      "refresh_token_url": "https://account.docusign.com/oauth/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/dropbox/app.json
+++ b/backend/apps/dropbox/app.json
@@ -7,24 +7,15 @@
   "description": "Dropbox is a cloud storage service that allows users to store, sync, and share files across devices. This integration provides comprehensive file management, sharing, and collaboration capabilities for automated workflows and content management.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://www.dropbox.com/oauth2/authorize",
-          "tokenUrl": "https://api.dropboxapi.com/oauth2/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_DROPBOX_APP_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_DROPBOX_APP_CLIENT_SECRET }}",
+      "scope": "files.metadata.write files.content.write",
       "authorize_url": "https://www.dropbox.com/oauth2/authorize",
-      "access_token_url": "https://api.dropboxapi.com/oauth2/token"
+      "access_token_url": "https://api.dropboxapi.com/oauth2/token",
+      "refresh_token_url": "https://api.dropboxapi.com/oauth2/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/figma/app.json
+++ b/backend/apps/figma/app.json
@@ -7,24 +7,15 @@
   "description": "Figma is a browser-based collaborative interface design tool. This integration allows access to and processing of Figma design files and resources.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://www.figma.com/oauth",
-          "tokenUrl": "https://www.figma.com/api/oauth/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ FIGMA_CLIENT_ID }}",
       "client_secret": "{{ FIGMA_CLIENT_SECRET }}",
+      "scope": "file_read",
       "authorize_url": "https://www.figma.com/oauth",
-      "access_token_url": "https://www.figma.com/api/oauth/token"
+      "access_token_url": "https://www.figma.com/api/oauth/token",
+      "refresh_token_url": "https://www.figma.com/api/oauth/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/github/app.json
+++ b/backend/apps/github/app.json
@@ -7,24 +7,15 @@
   "description": "The GitHub API allows you to interact with GitHub programmatically, including repository management, pull requests, issues, commits, and more.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://github.com/login/oauth/authorize",
-          "tokenUrl": "https://github.com/login/oauth/access_token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_GITHUB_APP_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_GITHUB_APP_CLIENT_SECRET }}",
+      "scope": "repo user",
       "authorize_url": "https://github.com/login/oauth/authorize",
-      "access_token_url": "https://github.com/login/oauth/access_token"
+      "access_token_url": "https://github.com/login/oauth/access_token",
+      "refresh_token_url": "https://github.com/login/oauth/access_token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/gitlab/app.json
+++ b/backend/apps/gitlab/app.json
@@ -7,24 +7,15 @@
   "description": "GitLab integration for AI agents",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://gitlab.com/oauth/authorize",
-          "tokenUrl": "https://gitlab.com/oauth/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ GITLAB_CLIENT_ID }}",
       "client_secret": "{{ GITLAB_CLIENT_SECRET }}",
+      "scope": "api read_api",
       "authorize_url": "https://gitlab.com/oauth/authorize",
-      "access_token_url": "https://gitlab.com/oauth/token"
+      "access_token_url": "https://gitlab.com/oauth/token",
+      "refresh_token_url": "https://gitlab.com/oauth/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/gmail/app.json
+++ b/backend/apps/gmail/app.json
@@ -7,24 +7,15 @@
   "description": "The Gmail API is a RESTful API that enables sending, reading, and managing emails. This integration allows sending emails on behalf of the user.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
-          "tokenUrl": "https://oauth2.googleapis.com/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_GMAIL_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_GMAIL_CLIENT_SECRET }}",
+      "scope": "https://www.googleapis.com/auth/gmail.send https://www.googleapis.com/auth/gmail.readonly",
       "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
-      "access_token_url": "https://oauth2.googleapis.com/token"
+      "access_token_url": "https://oauth2.googleapis.com/token",
+      "refresh_token_url": "https://oauth2.googleapis.com/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/google_analytics_admin/app.json
+++ b/backend/apps/google_analytics_admin/app.json
@@ -7,24 +7,15 @@
   "description": "The Google Analytics Admin API allows for programmatic access to the Google Analytics configuration data and is only compatible with Google Analytics properties.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
-          "tokenUrl": "https://oauth2.googleapis.com/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_GOOGLE_ANALYTICS_ADMIN_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_GOOGLE_ANALYTICS_ADMIN_CLIENT_SECRET }}",
+      "scope": "https://www.googleapis.com/auth/analytics.edit",
       "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
-      "access_token_url": "https://oauth2.googleapis.com/token"
+      "access_token_url": "https://oauth2.googleapis.com/token",
+      "refresh_token_url": "https://oauth2.googleapis.com/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/google_calendar/app.json
+++ b/backend/apps/google_calendar/app.json
@@ -7,24 +7,15 @@
   "description": "The Google Calendar API is a RESTful API that can be accessed through explicit HTTP calls. The API exposes most of the features available in the Google Calendar Web interface.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
-          "tokenUrl": "https://oauth2.googleapis.com/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_GOOGLE_CALENDAR_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_GOOGLE_CALENDAR_CLIENT_SECRET }}",
+      "scope": "https://www.googleapis.com/auth/calendar",
       "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
-      "access_token_url": "https://oauth2.googleapis.com/token"
+      "access_token_url": "https://oauth2.googleapis.com/token",
+      "refresh_token_url": "https://oauth2.googleapis.com/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/google_docs/app.json
+++ b/backend/apps/google_docs/app.json
@@ -7,24 +7,15 @@
   "description": "The Google Docs API allows developers to create, read, and update Google Docs documents programmatically. It provides access to Google Docs through RESTful HTTP calls, including create, read and update the Google Docs document.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
-          "tokenUrl": "https://oauth2.googleapis.com/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_GOOGLE_DOCS_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_GOOGLE_DOCS_CLIENT_SECRET }}",
+      "scope": "https://www.googleapis.com/auth/documents",
       "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
-      "access_token_url": "https://oauth2.googleapis.com/token"
+      "access_token_url": "https://oauth2.googleapis.com/token",
+      "refresh_token_url": "https://oauth2.googleapis.com/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/google_meet/app.json
+++ b/backend/apps/google_meet/app.json
@@ -7,24 +7,15 @@
   "description": "The Google Meet API allows developers to access and manage Google Meet resources programmatically. It provides information about meetings, participants, and recordings through RESTful HTTP calls including listing conference records, participants, and meeting spaces.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
-          "tokenUrl": "https://oauth2.googleapis.com/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_GOOGLE_MEET_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_GOOGLE_MEET_CLIENT_SECRET }}",
+      "scope": "https://www.googleapis.com/auth/meetings.space.created",
       "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
-      "access_token_url": "https://oauth2.googleapis.com/token"
+      "access_token_url": "https://oauth2.googleapis.com/token",
+      "refresh_token_url": "https://oauth2.googleapis.com/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/google_sheets/app.json
+++ b/backend/apps/google_sheets/app.json
@@ -7,24 +7,15 @@
   "description": "The Google Sheets API is a RESTful API that allows programmatic access to spreadsheet data and formatting. It supports CRUD operations, formulas, charts, and collaboration features.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
-          "tokenUrl": "https://oauth2.googleapis.com/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_GOOGLE_SHEETS_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_GOOGLE_SHEETS_CLIENT_SECRET }}",
+      "scope": "https://www.googleapis.com/auth/spreadsheets",
       "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
-      "access_token_url": "https://oauth2.googleapis.com/token"
+      "access_token_url": "https://oauth2.googleapis.com/token",
+      "refresh_token_url": "https://oauth2.googleapis.com/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/google_tasks/app.json
+++ b/backend/apps/google_tasks/app.json
@@ -7,24 +7,15 @@
   "description": "The Google Tasks API allows managing tasks and task lists programmatically.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
-          "tokenUrl": "https://oauth2.googleapis.com/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_GOOGLE_TASKS_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_GOOGLE_TASKS_CLIENT_SECRET }}",
+      "scope": "https://www.googleapis.com/auth/tasks",
       "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
-      "access_token_url": "https://oauth2.googleapis.com/token"
+      "access_token_url": "https://oauth2.googleapis.com/token",
+      "refresh_token_url": "https://oauth2.googleapis.com/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/hubspot/app.json
+++ b/backend/apps/hubspot/app.json
@@ -7,24 +7,15 @@
   "description": "HubSpot is a comprehensive CRM and inbound marketing platform that provides tools for sales, marketing, customer service, and content management. This integration enables AI agents to manage contacts, deals, companies, tickets, and marketing campaigns while tracking customer interactions and sales pipelines.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://app.hubspot.com/oauth/authorize",
-          "tokenUrl": "https://api.hubapi.com/oauth/v1/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ HUBSPOT_CLIENT_ID }}",
       "client_secret": "{{ HUBSPOT_CLIENT_SECRET }}",
+      "scope": "contacts",
       "authorize_url": "https://app.hubspot.com/oauth/authorize",
-      "access_token_url": "https://api.hubapi.com/oauth/v1/token"
+      "access_token_url": "https://api.hubapi.com/oauth/v1/token",
+      "refresh_token_url": "https://api.hubapi.com/oauth/v1/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/instagram/app.json
+++ b/backend/apps/instagram/app.json
@@ -7,24 +7,15 @@
   "description": "Instagram Business API provides comprehensive social media management capabilities for businesses to manage their Instagram presence. This integration enables AI agents to publish posts, manage stories, analyze engagement metrics, handle direct messages, manage business profiles, and automate content workflows for effective social media marketing and customer engagement.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://www.facebook.com/v20.0/dialog/oauth",
-          "tokenUrl": "https://graph.facebook.com/v20.0/oauth/access_token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ INSTAGRAM_CLIENT_ID }}",
       "client_secret": "{{ INSTAGRAM_CLIENT_SECRET }}",
+      "scope": "instagram_basic user_profile user_media",
       "authorize_url": "https://www.facebook.com/v20.0/dialog/oauth",
-      "access_token_url": "https://graph.facebook.com/v20.0/oauth/access_token"
+      "access_token_url": "https://graph.facebook.com/v20.0/oauth/access_token",
+      "refresh_token_url": "https://graph.facebook.com/v20.0/oauth/access_token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/intercom/app.json
+++ b/backend/apps/intercom/app.json
@@ -7,24 +7,15 @@
   "description": "Intercom is a customer messaging platform that enables businesses to communicate with customers through chat, email, and in-app messages. This integration provides comprehensive customer support, marketing automation, and user engagement capabilities for modern customer communication workflows.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://app.intercom.com/oauth",
-          "tokenUrl": "https://api.intercom.io/auth/eagle/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_INTERCOM_APP_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_INTERCOM_APP_CLIENT_SECRET }}",
+      "scope": "",
       "authorize_url": "https://app.intercom.com/oauth",
-      "access_token_url": "https://api.intercom.io/auth/eagle/token"
+      "access_token_url": "https://api.intercom.io/auth/eagle/token",
+      "refresh_token_url": "https://api.intercom.io/auth/eagle/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/jira/app.json
+++ b/backend/apps/jira/app.json
@@ -7,24 +7,15 @@
   "description": "Jira API integration for issue tracking and project management. Provides functionality to create, update, and manage issues, projects, and workflows.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://auth.atlassian.com/authorize?audience=api.atlassian.com&response_type=code&prompt=consent",
-          "tokenUrl": "https://auth.atlassian.com/oauth/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_JIRA_APP_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_JIRA_APP_CLIENT_SECRET }}",
+      "scope": "read:jira-user read:jira-work write:jira-work",
       "authorize_url": "https://auth.atlassian.com/authorize?audience=api.atlassian.com&response_type=code&prompt=consent",
-      "access_token_url": "https://auth.atlassian.com/oauth/token"
+      "access_token_url": "https://auth.atlassian.com/oauth/token",
+      "refresh_token_url": "https://auth.atlassian.com/oauth/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/linkedin/app.json
+++ b/backend/apps/linkedin/app.json
@@ -7,24 +7,15 @@
   "description": "LinkedIn API integration for professional networking, posting content, managing company pages, and accessing professional data. Enables programmatic access to LinkedIn's professional network and business features.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://www.linkedin.com/oauth/v2/authorization",
-          "tokenUrl": "https://www.linkedin.com/oauth/v2/accessToken",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_LINKEDIN_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_LINKEDIN_CLIENT_SECRET }}",
+      "scope": "r_liteprofile r_emailaddress w_member_social",
       "authorize_url": "https://www.linkedin.com/oauth/v2/authorization",
-      "access_token_url": "https://www.linkedin.com/oauth/v2/accessToken"
+      "access_token_url": "https://www.linkedin.com/oauth/v2/accessToken",
+      "refresh_token_url": "https://www.linkedin.com/oauth/v2/accessToken"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/microsoft_calendar/app.json
+++ b/backend/apps/microsoft_calendar/app.json
@@ -7,24 +7,15 @@
   "description": "The Microsoft Graph Calendar API enables access to Microsoft Calendar data including events, calendars, and scheduling. This integration allows reading and managing calendar content on behalf of the user.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
-          "tokenUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_MICROSOFT_CALENDAR_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_MICROSOFT_CALENDAR_CLIENT_SECRET }}",
+      "scope": "https://graph.microsoft.com/Calendars.ReadWrite",
       "authorize_url": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
-      "access_token_url": "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+      "access_token_url": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+      "refresh_token_url": "https://login.microsoftonline.com/common/oauth2/v2.0/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/microsoft_onedrive/app.json
+++ b/backend/apps/microsoft_onedrive/app.json
@@ -7,24 +7,15 @@
   "description": "The Microsoft Graph OneDrive API enables access to files and folders stored in OneDrive. This integration allows reading, managing, and searching OneDrive content on behalf of the user.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
-          "tokenUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_MICROSOFT_ONEDRIVE_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_MICROSOFT_ONEDRIVE_CLIENT_SECRET }}",
+      "scope": "https://graph.microsoft.com/Files.ReadWrite",
       "authorize_url": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
-      "access_token_url": "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+      "access_token_url": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+      "refresh_token_url": "https://login.microsoftonline.com/common/oauth2/v2.0/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/microsoft_outlook/app.json
+++ b/backend/apps/microsoft_outlook/app.json
@@ -7,24 +7,15 @@
   "description": "The Microsoft Graph Outlook API enables access to Microsoft Outlook data including emails, folders, contacts, and mail settings. This integration allows reading and managing Outlook content on behalf of the user.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
-          "tokenUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_MICROSOFT_OUTLOOK_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_MICROSOFT_OUTLOOK_CLIENT_SECRET }}",
+      "scope": "https://graph.microsoft.com/Mail.ReadWrite https://graph.microsoft.com/Mail.Send",
       "authorize_url": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
-      "access_token_url": "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+      "access_token_url": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+      "refresh_token_url": "https://login.microsoftonline.com/common/oauth2/v2.0/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/microsoft_teams/app.json
+++ b/backend/apps/microsoft_teams/app.json
@@ -7,24 +7,15 @@
   "description": "The Microsoft Graph Teams API enables access to Microsoft Teams data including teams, channels, messages, and team settings. This integration allows managing Teams content and collaboration on behalf of the user.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
-          "tokenUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_MICROSOFT_TEAMS_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_MICROSOFT_TEAMS_CLIENT_SECRET }}",
+      "scope": "https://graph.microsoft.com/Chat.ReadWrite",
       "authorize_url": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
-      "access_token_url": "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+      "access_token_url": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+      "refresh_token_url": "https://login.microsoftonline.com/common/oauth2/v2.0/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/notion/app.json
+++ b/backend/apps/notion/app.json
@@ -7,24 +7,15 @@
   "description": "Notion API is a REST API to manage Notion workspaces which are collaborative environments where teams can organize work, manage projects, and store information in a highly customizable way.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://api.notion.com/v1/oauth/authorize",
-          "tokenUrl": "https://api.notion.com/v1/oauth/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_NOTION_APP_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_NOTION_APP_CLIENT_SECRET }}",
+      "scope": "",
       "authorize_url": "https://api.notion.com/v1/oauth/authorize",
-      "access_token_url": "https://api.notion.com/v1/oauth/token"
+      "access_token_url": "https://api.notion.com/v1/oauth/token",
+      "refresh_token_url": "https://api.notion.com/v1/oauth/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/pagerduty/app.json
+++ b/backend/apps/pagerduty/app.json
@@ -7,24 +7,15 @@
   "description": "PagerDuty is a digital operations management platform that empowers teams to proactively mitigate issues that matter to their business before customers are impacted. This integration provides comprehensive incident management, alerting, and on-call scheduling capabilities.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://app.pagerduty.com/oauth/authorize",
-          "tokenUrl": "https://app.pagerduty.com/oauth/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_PAGERDUTY_APP_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_PAGERDUTY_APP_CLIENT_SECRET }}",
+      "scope": "",
       "authorize_url": "https://app.pagerduty.com/oauth/authorize",
-      "access_token_url": "https://app.pagerduty.com/oauth/token"
+      "access_token_url": "https://app.pagerduty.com/oauth/token",
+      "refresh_token_url": "https://app.pagerduty.com/oauth/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/quickbooks/app.json
+++ b/backend/apps/quickbooks/app.json
@@ -7,24 +7,15 @@
   "description": "QuickBooks is a comprehensive accounting software platform that helps businesses manage finances, invoicing, payments, and payroll. This integration provides complete financial management capabilities for automated accounting workflows and business intelligence.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://appcenter.intuit.com/connect/oauth2",
-          "tokenUrl": "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_QUICKBOOKS_APP_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_QUICKBOOKS_APP_CLIENT_SECRET }}",
+      "scope": "com.intuit.quickbooks.accounting",
       "authorize_url": "https://appcenter.intuit.com/connect/oauth2",
-      "access_token_url": "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer"
+      "access_token_url": "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer",
+      "refresh_token_url": "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/reddit/app.json
+++ b/backend/apps/reddit/app.json
@@ -7,24 +7,15 @@
   "description": "The Reddit API allows you to interact with Reddit programmatically, including post management, comments, user interactions, and subreddit operations.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://www.reddit.com/api/v1/authorize",
-          "tokenUrl": "https://www.reddit.com/api/v1/access_token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_REDDIT_APP_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_REDDIT_APP_CLIENT_SECRET }}",
+      "scope": "read submit",
       "authorize_url": "https://www.reddit.com/api/v1/authorize",
-      "access_token_url": "https://www.reddit.com/api/v1/access_token"
+      "access_token_url": "https://www.reddit.com/api/v1/access_token",
+      "refresh_token_url": "https://www.reddit.com/api/v1/access_token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/salesforce/app.json
+++ b/backend/apps/salesforce/app.json
@@ -7,24 +7,15 @@
   "description": "Salesforce is the world's leading customer relationship management (CRM) platform. This integration enables comprehensive access to sales, marketing, and service data including accounts, contacts, leads, opportunities, cases, and campaigns.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://login.salesforce.com/services/oauth2/authorize",
-          "tokenUrl": "https://login.salesforce.com/services/oauth2/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_SALESFORCE_APP_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_SALESFORCE_APP_CLIENT_SECRET }}",
+      "scope": "api refresh_token",
       "authorize_url": "https://login.salesforce.com/services/oauth2/authorize",
-      "access_token_url": "https://login.salesforce.com/services/oauth2/token"
+      "access_token_url": "https://login.salesforce.com/services/oauth2/token",
+      "refresh_token_url": "https://login.salesforce.com/services/oauth2/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/share_point/app.json
+++ b/backend/apps/share_point/app.json
@@ -7,24 +7,15 @@
   "description": "The Microsoft Graph SharePoint API enables access to SharePoint sites, lists, libraries, and files. This integration allows reading and managing SharePoint content on behalf of the user.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
-          "tokenUrl": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_SHARE_POINT_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_SHARE_POINT_CLIENT_SECRET }}",
+      "scope": "https://graph.microsoft.com/Sites.ReadWrite.All",
       "authorize_url": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
-      "access_token_url": "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+      "access_token_url": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+      "refresh_token_url": "https://login.microsoftonline.com/common/oauth2/v2.0/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/slack/app.json
+++ b/backend/apps/slack/app.json
@@ -7,24 +7,15 @@
   "description": "Slack is a team communication and collaboration tool. This API allows you to interact with Slack in two ways: as a bot for automated tasks and workflows, or as a user to perform actions on behalf of a real Slack user. Whether you're building chatbots, automating workflows, or integrating Slack with other tools, this API provides the flexibility to suit your needs.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://slack.com/oauth/v2/authorize",
-          "tokenUrl": "https://slack.com/api/oauth.v2.access",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_SLACK_APP_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_SLACK_APP_CLIENT_SECRET }}",
+      "scope": "channels:read chat:write files:read users:read",
       "authorize_url": "https://slack.com/oauth/v2/authorize",
-      "access_token_url": "https://slack.com/api/oauth.v2.access"
+      "access_token_url": "https://slack.com/api/oauth.v2.access",
+      "refresh_token_url": "https://slack.com/api/oauth.v2.access"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/trello/app.json
+++ b/backend/apps/trello/app.json
@@ -7,24 +7,15 @@
   "description": "Trello is a visual project management tool that uses boards, lists, and cards to organize tasks and workflows. This integration provides comprehensive project management capabilities for team collaboration, task tracking, and workflow automation.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://trello.com/1/authorize",
-          "tokenUrl": "https://api.trello.com/1/OAuthGetAccessToken",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_TRELLO_APP_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_TRELLO_APP_CLIENT_SECRET }}",
+      "scope": "read,write",
       "authorize_url": "https://trello.com/1/authorize",
-      "access_token_url": "https://api.trello.com/1/OAuthGetAccessToken"
+      "access_token_url": "https://trello.com/1/OAuthGetAccessToken",
+      "refresh_token_url": "https://trello.com/1/OAuthGetAccessToken"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/typeform/app.json
+++ b/backend/apps/typeform/app.json
@@ -7,24 +7,15 @@
   "description": "uLutypeform integration for AI agents",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://api.typeform.com/oauth/authorize",
-          "tokenUrl": "https://api.typeform.com/oauth/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ TYPEFORM_CLIENT_ID }}",
       "client_secret": "{{ TYPEFORM_CLIENT_SECRET }}",
+      "scope": "accounts:read forms:read responses:read forms:write",
       "authorize_url": "https://api.typeform.com/oauth/authorize",
-      "access_token_url": "https://api.typeform.com/oauth/token"
+      "access_token_url": "https://api.typeform.com/oauth/token",
+      "refresh_token_url": "https://api.typeform.com/oauth/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/x/app.json
+++ b/backend/apps/x/app.json
@@ -7,24 +7,15 @@
   "description": "X API v2 integration for accessing posts, users, communities, trends, and social interactions. Provides programmatic access to X's global conversation with real-time data and advanced analytics.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://x.com/i/oauth2/authorize",
-          "tokenUrl": "https://api.x.com/2/oauth2/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_X_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_X_CLIENT_SECRET }}",
+      "scope": "tweet.read tweet.write users.read",
       "authorize_url": "https://x.com/i/oauth2/authorize",
-      "access_token_url": "https://api.x.com/2/oauth2/token"
+      "access_token_url": "https://api.x.com/2/oauth2/token",
+      "refresh_token_url": "https://api.x.com/2/oauth2/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/youtube/app.json
+++ b/backend/apps/youtube/app.json
@@ -7,24 +7,15 @@
   "description": "YouTube API provides access to Google's streaming video repository, allowing you to search for videos, retrieve standard feeds, and manage YouTube subscriptions and playlists.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
-          "tokenUrl": "https://oauth2.googleapis.com/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_YOUTUBE_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_YOUTUBE_CLIENT_SECRET }}",
+      "scope": "https://www.googleapis.com/auth/youtube",
       "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
-      "access_token_url": "https://oauth2.googleapis.com/token"
+      "access_token_url": "https://oauth2.googleapis.com/token",
+      "refresh_token_url": "https://oauth2.googleapis.com/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/zapier/app.json
+++ b/backend/apps/zapier/app.json
@@ -7,24 +7,15 @@
   "description": "Zapier is a workflow automation platform that connects apps and automates repetitive tasks. This integration enables creation and management of Zaps (automated workflows), triggers, actions, and webhook-based automation between different applications.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://zapier.com/oauth/authorize/",
-          "tokenUrl": "https://zapier.com/oauth/token/",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ ZAPIER_CLIENT_ID }}",
       "client_secret": "{{ ZAPIER_CLIENT_SECRET }}",
+      "scope": "",
       "authorize_url": "https://zapier.com/oauth/authorize/",
-      "access_token_url": "https://zapier.com/oauth/token/"
+      "access_token_url": "https://zapier.com/oauth/token/",
+      "refresh_token_url": "https://zapier.com/oauth/token/"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/zendesk/app.json
+++ b/backend/apps/zendesk/app.json
@@ -7,24 +7,15 @@
   "description": "uLuzendesk integration for AI agents",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://{subdomain}.zendesk.com/oauth/authorizations/new",
-          "tokenUrl": "https://{subdomain}.zendesk.com/oauth/tokens",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ ZENDESK_CLIENT_ID }}",
       "client_secret": "{{ ZENDESK_CLIENT_SECRET }}",
+      "scope": "read write",
       "authorize_url": "https://{subdomain}.zendesk.com/oauth/authorizations/new",
-      "access_token_url": "https://{subdomain}.zendesk.com/oauth/tokens"
+      "access_token_url": "https://{subdomain}.zendesk.com/oauth/tokens",
+      "refresh_token_url": "https://{subdomain}.zendesk.com/oauth/tokens"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/zoho_desk/app.json
+++ b/backend/apps/zoho_desk/app.json
@@ -7,24 +7,15 @@
   "description": "Zoho Desk API integration for customer support and ticket management. Provides access to tickets, contacts, departments, and customer support features.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://accounts.zoho.com/oauth/v2/auth",
-          "tokenUrl": "https://accounts.zoho.com/oauth/v2/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_ZOHO_APP_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_ZOHO_APP_CLIENT_SECRET }}",
+      "scope": "Desk.tickets.ALL Desk.contacts.READ Desk.contacts.WRITE",
       "authorize_url": "https://accounts.zoho.com/oauth/v2/auth",
-      "access_token_url": "https://accounts.zoho.com/oauth/v2/token"
+      "access_token_url": "https://accounts.zoho.com/oauth/v2/token",
+      "refresh_token_url": "https://accounts.zoho.com/oauth/v2/token"
     }
   },
   "default_security_credentials_by_scheme": {},

--- a/backend/apps/zoom/app.json
+++ b/backend/apps/zoom/app.json
@@ -7,24 +7,15 @@
   "description": "Zoom is a video communications platform providing meetings, webinars, and collaboration tools. This integration enables comprehensive management of meetings, participants, recordings, and real-time communication features for remote collaboration.",
   "security_schemes": {
     "oauth2": {
-      "type": "oauth2",
-      "flows": {
-        "authorizationCode": {
-          "authorizationUrl": "https://zoom.us/oauth/authorize",
-          "tokenUrl": "https://zoom.us/oauth/token",
-          "scopes": {
-            "read": "Read access",
-            "write": "Write access"
-          }
-        }
-      },
       "location": "header",
       "name": "Authorization",
       "prefix": "Bearer",
       "client_id": "{{ AIPOLABS_ZOOM_APP_CLIENT_ID }}",
       "client_secret": "{{ AIPOLABS_ZOOM_APP_CLIENT_SECRET }}",
+      "scope": "meeting:write",
       "authorize_url": "https://zoom.us/oauth/authorize",
-      "access_token_url": "https://zoom.us/oauth/token"
+      "access_token_url": "https://zoom.us/oauth/token",
+      "refresh_token_url": "https://zoom.us/oauth/token"
     }
   },
   "default_security_credentials_by_scheme": {},


### PR DESCRIPTION
- Update all 43 OAuth2 apps to use proper API-specific scopes
- Google APIs: Use googleapis.com scopes (gmail.send, calendar, spreadsheets, etc.)
- Microsoft APIs: Use graph.microsoft.com scopes (Mail.ReadWrite, Calendars.ReadWrite, etc.)
- Major platforms: API-specific scopes (Slack: channels:read chat:write, GitHub: repo user)
- Business tools: Correct scopes (HubSpot: contacts, Salesforce: api refresh_token)
- No-scope apps: Properly configured for APIs that don't use OAuth2 scopes
- All apps follow INTEGRATION_GUIDE.md format with proper OAuth2 structure

🤖 Generated with [Claude Code](https://claude.ai/code)

### 🏷️ Ticket

[link the issue or ticket you are addressing in this PR here, or use the **Development**
section on the right sidebar to link the issue]

### 📝 Description

[Describe your changes in detail (optional if the issue you linked already contains a
detail description of the change)]

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed
