### PR TITLE
scale aci backend pods and workers

### DIFF
--- a/.github/workflows/backend-deployment.yml
+++ b/.github/workflows/backend-deployment.yml
@@ -25,7 +25,7 @@ jobs:
         if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
           BRANCH_NAME="prod"
           NAMESPACE="aci-prod"
-          REPLICAS="1"
+          REPLICAS="3"
           POSTGRES_INSTANCES="2"
           DOMAIN="aci-api.assista.dev"
           APPLY_HPA="true"

--- a/backend/Dockerfile.server.prod
+++ b/backend/Dockerfile.server.prod
@@ -8,6 +8,7 @@ RUN uv sync --no-dev --no-install-project
 
 ENV PATH="/workdir/.venv/bin:$PATH"
 ENV PYTHONPATH=/workdir
+ENV UVICORN_WORKERS=4
 
 RUN playwright install chromium --with-deps --no-shell
 
@@ -26,4 +27,4 @@ RUN rm -rf /workdir/aci/server/tests
 
 COPY .env.prod .env
 
-CMD ["uvicorn", "aci.server.main:app", "--proxy-headers", "--forwarded-allow-ips=*", "--host", "0.0.0.0", "--port", "8000", "--no-access-log"]
+CMD ["sh", "-c", "uvicorn aci.server.main:app --proxy-headers --forwarded-allow-ips=* --host 0.0.0.0 --port 8000 --no-access-log --workers ${UVICORN_WORKERS}"]

--- a/backend/k8s/hpa.yaml
+++ b/backend/k8s/hpa.yaml
@@ -8,8 +8,8 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: aci-backend
-  minReplicas: 1
-  maxReplicas: 5
+  minReplicas: 3
+  maxReplicas: 15
   metrics:
   - type: Resource
     resource:


### PR DESCRIPTION
 - Recent Grafana/Loki checks confirmed pods were failing liveness probes because the single uvicorn worker blocked on outgoing REST calls; DB logs only showed resets after kubelet killed the pods.
 - Raised the backend’s concurrency headroom by running uvicorn with 4 workers per pod, defaulting prod deployments to 3 replicas, and widening the HPA window to 3–15 replicas so Kubernetes can scale faster under load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production infrastructure configuration with increased deployment replicas and worker process allocation to enhance system scalability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->