### PR TITLE
raise backend pod resources

### DIFF
--- a/backend/k8s/deployment.yaml
+++ b/backend/k8s/deployment.yaml
@@ -172,8 +172,8 @@ spec:
         
         resources:
           requests:
-            memory: "1Gi"
-            cpu: "500m"
-          limits:
             memory: "2Gi"
             cpu: "1000m"
+          limits:
+            memory: "4Gi"
+            cpu: "2000m"


### PR DESCRIPTION
 raise per-pod CPU/memory requests/limits so the autoscaler stops thrashing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized backend infrastructure resource allocation for improved application stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->