### PR TITLE
temporarily increase aci size (for demo)

### DIFF
--- a/backend/Dockerfile.server.prod
+++ b/backend/Dockerfile.server.prod
@@ -8,7 +8,7 @@ RUN uv sync --no-dev --no-install-project
 
 ENV PATH="/workdir/.venv/bin:$PATH"
 ENV PYTHONPATH=/workdir
-ENV UVICORN_WORKERS=6
+ENV UVICORN_WORKERS=10
 
 RUN playwright install chromium --with-deps --no-shell
 

--- a/backend/k8s/deployment.yaml
+++ b/backend/k8s/deployment.yaml
@@ -172,8 +172,8 @@ spec:
         
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "500m"
+            memory: "4Gi"
+            cpu: "1000m"
           limits:
             memory: "4Gi"
             cpu: "1000m"

--- a/backend/k8s/hpa.yaml
+++ b/backend/k8s/hpa.yaml
@@ -8,8 +8,8 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: aci-backend
-  minReplicas: 15
-  maxReplicas: 50
+  minReplicas: 10
+  maxReplicas: 30
   metrics:
   - type: Resource
     resource:


### PR DESCRIPTION
Increase ACI size and replicas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased backend worker processes to handle higher throughput (from 4 to 10 workers).
  * Raised backend container resource requests and limits (memory and CPU increased for more capacity).
  * Expanded autoscaling range to support more replicas during peak demand (min and max replicas increased).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->