### PR TITLE
Fix cache invalidation by updating query key version

### DIFF
--- a/frontend/src/hooks/use-linked-account.tsx
+++ b/frontend/src/hooks/use-linked-account.tsx
@@ -23,7 +23,7 @@ import { LinkedAccount } from "@/lib/types/linkedaccount";
 import { toast } from "sonner";
 
 export const linkedAccountKeys = {
-  all: (projectId: string) => [projectId, "linkedaccounts"] as const,
+  all: (projectId: string) => [projectId, "linkedaccounts", "v2"] as const, // v2: pagination fix
   paginated: (projectId: string, filters?: Partial<GetLinkedAccountsParams>) =>
     [projectId, "linkedaccounts", "paginated", filters] as const,
 };


### PR DESCRIPTION
This forces React Query to refetch with the new paginated API format, resolving the 'e.data.filter is not a function' error on production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### 🏷️ Ticket

[link the issue or ticket you are addressing in this PR here, or use the **Development**
section on the right sidebar to link the issue]

### 📝 Description

[Describe your changes in detail (optional if the issue you linked already contains a
detail description of the change)]

### 🎥 Demo (if applicable)

### 📸 Screenshots (if applicable)

### ✅ Checklist

- [ ] I have signed the [Contributor License Agreement]() (CLA) and read the [contributing guide](./../CONTRIBUTING.md) (required)
- [ ] I have linked this PR to an issue or a ticket (required)
- [ ] I have updated the documentation related to my change if needed
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature)
- [ ] All checks on CI passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal cache key structure for linked accounts queries to support enhanced data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->